### PR TITLE
Update to use generics?

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module main
+
+go 1.21.7

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/Joker666/AsyncGoDemo/async"
+	"main/async"
 	"time"
 )
 
@@ -15,9 +15,7 @@ func DoneAsync() int {
 
 func main() {
 	fmt.Println("Let's start ...")
-	future := async.Exec(func() interface{} {
-		return DoneAsync()
-	})
+	future := async.Exec(DoneAsync)
 	fmt.Println("Done is running ...")
 	val := future.Await()
 	fmt.Println(val)


### PR DESCRIPTION
Hey! I love this [post](https://hackernoon.com/asyncawait-in-golang-an-introductory-guide-ol1e34sg)

While doing some tests/ demoing I wanted to add generics support to this snippet.

Also, I've updated to go 1.21.7

These changes bring IntelliSense/ easy to remember which type is coming from this _Future_
<img width="516" alt="Screenshot 2024-03-03 at 21 25 33" src="https://github.com/Joker666/AsyncGoDemo/assets/70247653/20dc5511-e6a3-4752-ac70-1c23ec71d5ed">
> Future of int will return int